### PR TITLE
Fix map overflowing nav area 

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -13,6 +13,7 @@ body,
 dd,
 dl,
 figure,
+h1,
 h2,
 h3,
 h4,
@@ -20,8 +21,8 @@ p {
   margin: 0;
 }
 
-ol[role='list'],
-ul[role='list'] {
+ol,
+ul {
   list-style: none;
 }
 
@@ -50,46 +51,64 @@ textarea {
    
 \*--------------------------------------------------------------------------*/
 
-body {
-  margin: 0;
-  line-height: 1.5;
-  color: #1c2334;
-}
-
 html,
 body,
 #root {
   height: 100%;
 }
 
+body {
+  margin: 0;
+  line-height: 1.5;
+  color: #1c2334;
+  font-family: Barlow Condensed, Helvetica, sans-serif;
+}
+
 .app {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
   max-width: 75rem;
   margin-left: auto;
   margin-right: auto;
-  padding: 0 1.33rem;
-  min-height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
+  padding: 1rem;
 }
 
-.map-area {
-  height: 70vh;
+.app > .map {
+  margin-top: auto;
+  margin-bottom: auto;
 }
 
 .map {
+  height: 70vh;
+}
+
+.app > :first-child:not(main) {
+  margin-top: 0;
+}
+
+.app > :last-child:not(main) {
+  margin-bottom: 0;
+}
+
+h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  line-height: 1.12;
+  text-align: center;
+}
+
+main > h1 + * {
+  margin-top: 1rem;
+}
+
+.map__inner {
   width: 100%;
   height: 100%;
 }
 
-h1 {
-  text-align: center;
-}
-
 footer {
   margin-top: auto;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
   text-align: center;
 }
 
@@ -104,27 +123,20 @@ nav {
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
-  gap: 0 0.75rem;
+  gap: 0.75rem;
   margin: 0;
   padding: 0;
-  font-size: 1rem;
-  font-weight: 700;
-  list-style: none;
 }
 
 .nav li {
-  margin: 0;
-}
-
-@media (min-width: 20em) {
-  .nav li {
-    margin: 0.15rem 0.5rem;
-  }
+  margin: 0.15rem 0.5rem;
+  max-width: 65ch;
 }
 
 .nav a {
   color: #1c2334;
   font-size: 1rem;
+  font-weight: 700;
   line-height: 1.5;
   cursor: pointer;
   text-decoration: none;

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -13,16 +13,18 @@ const Map = () => {
   };
 
   return (
-    <div className="map-area">
+    <>
       <h1>What's Near Me?</h1>
       <div className="map">
-        <GoogleMapReact
-          bootstrapURLKeys={{ key }}
-          defaultCenter={center}
-          defaultZoom={zoom}
-        />
+        <div className="map__inner">
+          <GoogleMapReact
+            bootstrapURLKeys={{ key }}
+            defaultCenter={center}
+            defaultZoom={zoom}
+          />
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Description

This PR fixes map overflowing nav area.

## Acceptance Criteria

- map and navbar are laid out vertically
- map and navbar do not come into contact with each other
-  no overflows, overlaps and other breakages between 2 elements

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|     | :sparkles: New feature     |
| ✓  | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

![Screenshot 2021-07-18 at 00 48 47](https://user-images.githubusercontent.com/74302233/126050097-6ba332ba-2deb-4ec6-bf14-82abdde2645f.png)


### After

![Screenshot 2021-07-18 at 00 49 41](https://user-images.githubusercontent.com/74302233/126050121-1298e286-4a1b-4920-9d82-a9980be2b69c.png)


## Testing Steps / QA Criteria

- From your terminal, pull down this branch with ``ku-am-fix-navbar-alignment`` and check out the branch with ``ku-am-fix-navbar-alignment``
- Run ``npm install`` to install necessary dependencies and then ``npm start`` to launch the app
- Make sure map and nav do not come in contact with each other and that there're no overflows, overlaps and other breakages

