### PR TITLE
[TCL-30] Make bottom navigation menu stay visible in the viewport irrespective of page content length

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -65,30 +65,20 @@ body {
 }
 
 .app {
-  display: flex;
-  flex-direction: column;
-  min-height: 100%;
+  display: grid;
+  grid-template-rows: 1fr auto;
+  min-height: 100vh;
+  max-height: 100vh;
   max-width: 75rem;
   margin-left: auto;
   margin-right: auto;
   padding: 1rem;
 }
 
-.app > .map {
-  margin-top: auto;
-  margin-bottom: auto;
-}
-
-.map {
-  height: 70vh;
-}
-
-.app > :first-child:not(main) {
-  margin-top: 0;
-}
-
-.app > :last-child:not(main) {
-  margin-bottom: 0;
+.app__content {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  overflow: hidden;
 }
 
 h1 {
@@ -102,9 +92,16 @@ main > h1 + * {
   margin-top: 1rem;
 }
 
-.map__inner {
-  width: 100%;
+.view__content {
+  overflow-y: auto;
+}
+
+.map {
+  display: flex;
+  flex-direction: column;
   height: 100%;
+  height: 80vh;
+  margin: 0;
 }
 
 footer {

--- a/src/App.css
+++ b/src/App.css
@@ -97,11 +97,7 @@ main > h1 + * {
 }
 
 .map {
-  display: flex;
-  flex-direction: column;
   height: 100%;
-  height: 80vh;
-  margin: 0;
 }
 
 footer {

--- a/src/App.css
+++ b/src/App.css
@@ -142,3 +142,8 @@ nav {
 a.active {
   text-decoration: underline;
 }
+
+.list {
+  min-height: 100%;
+  padding: 0;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ const App = () => {
   return (
     <Router>
       <div className="app">
-        <main>
+        <main className="app__content">
           <Switch>
             <Route path="/" exact component={Map} />
             <Route path="/list" component={List} />

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -1,5 +1,12 @@
 import React from 'react';
 
-const List = () => <h1>List</h1>;
+const List = () => (
+  <>
+    <h1>List</h1>
+    <div class="view__content">
+      {/* your <ul> should live inside the view__content div */}
+    </div>
+  </>
+);
 
 export default List;

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -4,7 +4,7 @@ const List = () => (
   <>
     <h1>List</h1>
     <div class="view__content">
-      {/* your <ul> should live inside the view__content div */}
+      <ul class="list"></ul>
     </div>
   </>
 );

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -4,7 +4,69 @@ const List = () => (
   <>
     <h1>List</h1>
     <div class="view__content">
-      <ul class="list"></ul>
+      <ul class="list">
+        {/* these list items here are for testing purposes only and should be deleted before merging */}
+        <li class="item">
+          <div class="image">
+            <img
+              src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/La_Tour_Eiffel_vue_de_la_Tour_Saint-Jacques%2C_Paris_ao%C3%BBt_2014_%282%29.jpg/500px-La_Tour_Eiffel_vue_de_la_Tour_Saint-Jacques%2C_Paris_ao%C3%BBt_2014_%282%29.jpg"
+              alt="Paris"
+            />
+          </div>
+
+          <div class="text">
+            <h2 class="item__title">Paris</h2>
+            <p class="item__description">
+              Capital and most populous city of France
+            </p>
+          </div>
+        </li>
+        <li class="item">
+          <div class="image">
+            <img
+              src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/La_Tour_Eiffel_vue_de_la_Tour_Saint-Jacques%2C_Paris_ao%C3%BBt_2014_%282%29.jpg/500px-La_Tour_Eiffel_vue_de_la_Tour_Saint-Jacques%2C_Paris_ao%C3%BBt_2014_%282%29.jpg"
+              alt="Paris"
+            />
+          </div>
+
+          <div class="text">
+            <h2 class="item__title">Paris</h2>
+            <p class="item__description">
+              Capital and most populous city of France
+            </p>
+          </div>
+        </li>
+        <li class="item">
+          <div class="image">
+            <img
+              src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/La_Tour_Eiffel_vue_de_la_Tour_Saint-Jacques%2C_Paris_ao%C3%BBt_2014_%282%29.jpg/500px-La_Tour_Eiffel_vue_de_la_Tour_Saint-Jacques%2C_Paris_ao%C3%BBt_2014_%282%29.jpg"
+              alt="Paris"
+            />
+          </div>
+
+          <div class="text">
+            <h2 class="item__title">Paris</h2>
+            <p class="item__description">
+              Capital and most populous city of France
+            </p>
+          </div>
+        </li>
+        <li class="item">
+          <div class="image">
+            <img
+              src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/La_Tour_Eiffel_vue_de_la_Tour_Saint-Jacques%2C_Paris_ao%C3%BBt_2014_%282%29.jpg/500px-La_Tour_Eiffel_vue_de_la_Tour_Saint-Jacques%2C_Paris_ao%C3%BBt_2014_%282%29.jpg"
+              alt="Paris"
+            />
+          </div>
+
+          <div class="text">
+            <h2 class="item__title">Paris</h2>
+            <p class="item__description">
+              Capital and most populous city of France
+            </p>
+          </div>
+        </li>
+      </ul>
     </div>
   </>
 );

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -15,8 +15,8 @@ const Map = () => {
   return (
     <>
       <h1>What's Near Me?</h1>
-      <div className="map">
-        <div className="map__inner">
+      <div className="view__content">
+        <div className="map">
           <GoogleMapReact
             bootstrapURLKeys={{ key }}
             defaultCenter={center}


### PR DESCRIPTION
## Description

This PR makes sure that the app's nav bar is always visible in the viewport no matter how long the content of the page is. It  defines app content areas with ``grid`` and ``grid-template-rows``and uses ``overflow:hidden`` and ``overflow-y:auto``  to control which areas on the page should be scrollable and non-scrollable.


## Acceptance Criteria

- Nav bar should be pinned to the bottom of the viewport 
- Nav bar should always stay visible in the viewport and should not be affected by the page content length

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓ | :bug: Bug fix              |
|     | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
The navbar was not visible in the viewport and could only be seen if the user scrolled down to the bottom of the page
![with no footer](https://user-images.githubusercontent.com/16920088/126702124-40afb45e-400d-4c0e-b17f-38a26f51f486.png)

### After

The navbar stays visible in the viewport despite the content length
![with footer](https://user-images.githubusercontent.com/16920088/126702103-aca1a905-0c8e-4f7f-9631-df2bf6dd3cf0.png)




## Testing Steps / QA Criteria

- From your terminal, pull down this branch - ``ku-fix-make-navbar-always-visible-in-the-viewport``
-  Run ``npm start`` to launch the app
-  Make sure the nav bar is always at the bottom of the page
