### PR TITLE
[TCL30-11] Add Info Window To Pin 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "whats-near-me",
       "version": "0.1.0",
       "dependencies": {
+        "@reach/dialog": "^0.15.3",
         "google-map-react": "^2.1.10",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
@@ -2743,6 +2744,49 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@reach/dialog": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@reach/dialog/-/dialog-0.15.3.tgz",
+      "integrity": "sha512-fF9Wkk4CCuKqRLko92hhElV2mZJpYhq7F97aP0iLyP31xz14/hcFnM3/qocxnKW5V1nA41xl0/yZfxljfyuwig==",
+      "dependencies": {
+        "@reach/portal": "0.15.3",
+        "@reach/utils": "0.15.3",
+        "prop-types": "^15.7.2",
+        "react-focus-lock": "^2.5.1",
+        "react-remove-scroll": "^2.4.2",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@reach/portal": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.15.3.tgz",
+      "integrity": "sha512-9VkVEQIF9gK73uK1f9MYhrJivd0dpxhkBEb2zwVCIEGvKVxadmRNmCjgcWexGjA0UeCjIhEjQQehs/IZHNLPdw==",
+      "dependencies": {
+        "@reach/utils": "0.15.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "node_modules/@reach/utils": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.15.3.tgz",
+      "integrity": "sha512-HFyjw8LZ4/RRk5bcMpDAeEc3aOeLR/vWRDsljlE3cHI5GfFlZcG3DDLSW8C2ba74RCFp/4X3Nz0nOrd4JdkZ1w==",
+      "dependencies": {
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -6874,6 +6918,11 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
     "node_modules/detect-port-alt": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
@@ -8902,6 +8951,17 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "node_modules/focus-lock": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.9.1.tgz",
+      "integrity": "sha512-/2Nj60Cps6yOLSO+CkVbeSKfwfns5XbX6HOedIK9PdzODP04N9c3xqOcPXayN0WsT9YjJvAnXmI0NdqNIDf5Kw==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
@@ -9280,6 +9340,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-own-enumerable-property-symbols": {
@@ -10316,6 +10384,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/ip": {
@@ -16217,6 +16293,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-clientside-effect": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.5.tgz",
+      "integrity": "sha512-2bL8qFW1TGBHozGGbVeyvnggRpMjibeZM2536AKNENLECutp2yfs44IL8Hmpn8qjFQ2K7A9PnYf3vc7aQq/cPA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.4.tgz",
@@ -16498,6 +16585,22 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
     },
+    "node_modules/react-focus-lock": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.2.tgz",
+      "integrity": "sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^0.9.1",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.5",
+        "use-callback-ref": "^1.2.5",
+        "use-sidecar": "^1.0.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -16510,6 +16613,61 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.4.3.tgz",
+      "integrity": "sha512-lGWYXfV6jykJwbFpsuPdexKKzp96f3RbvGapDSIdcyGvHb7/eqyn46C7/6h+rUzYar1j5mdU+XECITHXCKBk9Q==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.1.0",
+        "react-style-singleton": "^2.1.0",
+        "tslib": "^1.0.0",
+        "use-callback-ref": "^1.2.3",
+        "use-sidecar": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=8.5.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0",
+        "react": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.2.0.tgz",
+      "integrity": "sha512-UU9ZBP1wdMR8qoUs7owiVcpaPwsQxUDC2lypP6mmixaGlARZa7ZIBx1jcuObLdhMOvCsnZcvetOho0wzPa9PYg==",
+      "dependencies": {
+        "react-style-singleton": "^2.1.0",
+        "tslib": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.5.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0",
+        "react": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/react-remove-scroll/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/react-router": {
       "version": "5.2.0",
@@ -16760,6 +16918,33 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.1.1.tgz",
+      "integrity": "sha512-jNRp07Jza6CBqdRKNgGhT3u9umWvils1xsuMOjZlghBDH2MU0PL2WZor4PGYjXpnRCa9DQSlHMs/xnABWOwYbA==",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.5.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0",
+        "react": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/read-pkg": {
       "version": "3.0.0",
@@ -20126,6 +20311,43 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.5.tgz",
+      "integrity": "sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==",
+      "engines": {
+        "node": ">=8.5.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0",
+        "react": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.5.tgz",
+      "integrity": "sha512-k9jnrjYNwN6xYLj1iaGhonDghfvmeTmYjAiGvOr7clwKfPjMXJf4/HOr7oT5tJwYafgp2tG2l3eZEOfoELiMcA==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/use-sidecar/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/util": {
       "version": "0.11.1",
@@ -24103,6 +24325,37 @@
         }
       }
     },
+    "@reach/dialog": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@reach/dialog/-/dialog-0.15.3.tgz",
+      "integrity": "sha512-fF9Wkk4CCuKqRLko92hhElV2mZJpYhq7F97aP0iLyP31xz14/hcFnM3/qocxnKW5V1nA41xl0/yZfxljfyuwig==",
+      "requires": {
+        "@reach/portal": "0.15.3",
+        "@reach/utils": "0.15.3",
+        "prop-types": "^15.7.2",
+        "react-focus-lock": "^2.5.1",
+        "react-remove-scroll": "^2.4.2",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@reach/portal": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.15.3.tgz",
+      "integrity": "sha512-9VkVEQIF9gK73uK1f9MYhrJivd0dpxhkBEb2zwVCIEGvKVxadmRNmCjgcWexGjA0UeCjIhEjQQehs/IZHNLPdw==",
+      "requires": {
+        "@reach/utils": "0.15.3",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@reach/utils": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.15.3.tgz",
+      "integrity": "sha512-HFyjw8LZ4/RRk5bcMpDAeEc3aOeLR/vWRDsljlE3cHI5GfFlZcG3DDLSW8C2ba74RCFp/4X3Nz0nOrd4JdkZ1w==",
+      "requires": {
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      }
+    },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
@@ -27365,6 +27618,11 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
+    "detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
     "detect-port-alt": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
@@ -28909,6 +29167,14 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "focus-lock": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.9.1.tgz",
+      "integrity": "sha512-/2Nj60Cps6yOLSO+CkVbeSKfwfns5XbX6HOedIK9PdzODP04N9c3xqOcPXayN0WsT9YjJvAnXmI0NdqNIDf5Kw==",
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
     "follow-redirects": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
@@ -29196,6 +29462,11 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
       }
+    },
+    "get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
     },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.2",
@@ -29984,6 +30255,14 @@
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "ip": {
@@ -34636,6 +34915,14 @@
         "whatwg-fetch": "^3.4.1"
       }
     },
+    "react-clientside-effect": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.5.tgz",
+      "integrity": "sha512-2bL8qFW1TGBHozGGbVeyvnggRpMjibeZM2536AKNENLECutp2yfs44IL8Hmpn8qjFQ2K7A9PnYf3vc7aQq/cPA==",
+      "requires": {
+        "@babel/runtime": "^7.12.13"
+      }
+    },
     "react-dev-utils": {
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-11.0.4.tgz",
@@ -34850,6 +35137,19 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
     },
+    "react-focus-lock": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.2.tgz",
+      "integrity": "sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^0.9.1",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.5",
+        "use-callback-ref": "^1.2.5",
+        "use-sidecar": "^1.0.5"
+      }
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -34859,6 +35159,41 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
+    },
+    "react-remove-scroll": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.4.3.tgz",
+      "integrity": "sha512-lGWYXfV6jykJwbFpsuPdexKKzp96f3RbvGapDSIdcyGvHb7/eqyn46C7/6h+rUzYar1j5mdU+XECITHXCKBk9Q==",
+      "requires": {
+        "react-remove-scroll-bar": "^2.1.0",
+        "react-style-singleton": "^2.1.0",
+        "tslib": "^1.0.0",
+        "use-callback-ref": "^1.2.3",
+        "use-sidecar": "^1.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "react-remove-scroll-bar": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.2.0.tgz",
+      "integrity": "sha512-UU9ZBP1wdMR8qoUs7owiVcpaPwsQxUDC2lypP6mmixaGlARZa7ZIBx1jcuObLdhMOvCsnZcvetOho0wzPa9PYg==",
+      "requires": {
+        "react-style-singleton": "^2.1.0",
+        "tslib": "^1.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
     },
     "react-router": {
       "version": "5.2.0",
@@ -35038,6 +35373,23 @@
           "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
           "optional": true,
           "peer": true
+        }
+      }
+    },
+    "react-style-singleton": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.1.1.tgz",
+      "integrity": "sha512-jNRp07Jza6CBqdRKNgGhT3u9umWvils1xsuMOjZlghBDH2MU0PL2WZor4PGYjXpnRCa9DQSlHMs/xnABWOwYbA==",
+      "requires": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^1.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -37706,6 +38058,28 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "use-callback-ref": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.5.tgz",
+      "integrity": "sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==",
+      "requires": {}
+    },
+    "use-sidecar": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.5.tgz",
+      "integrity": "sha512-k9jnrjYNwN6xYLj1iaGhonDghfvmeTmYjAiGvOr7clwKfPjMXJf4/HOr7oT5tJwYafgp2tG2l3eZEOfoELiMcA==",
+      "requires": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
     },
     "util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@reach/dialog": "^0.15.3",
     "google-map-react": "^2.1.10",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/src/App.css
+++ b/src/App.css
@@ -432,8 +432,5 @@ button:hover {
 
 .dialog__body__link {
   color: #1c2334;
-}
-
-.dialog__body__link:hover {
   text-decoration: underline;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -377,6 +377,14 @@ a.active {
   }
 }
 
+button:focus {
+  outline-color: #f586ae;
+}
+
+button:hover {
+  background-color: #f586ae;
+}
+
 .dialog__button {
   background: none;
   border: 0;

--- a/src/App.css
+++ b/src/App.css
@@ -339,3 +339,19 @@ a.active {
 .location__title {
   text-align: left;
 }
+
+/* dialog */
+[role='‘dialog’'] {
+  padding: 20px;
+  background-color: white;
+  border: 2px solid fuchsia;
+  border-radius: 2px;
+}
+
+.dialog {
+  top: 50%;
+  bottom: auto;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  position: fixed;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -30,8 +30,8 @@ html:focus-within {
   scroll-behavior: smooth;
 }
 
-a:not([class]) {
-  text-decoration-skip-ink: auto;
+a {
+  text-decoration: none;
 }
 
 img,
@@ -340,18 +340,92 @@ a.active {
   text-align: left;
 }
 
-/* dialog */
-[role='‘dialog’'] {
-  padding: 20px;
-  background-color: white;
-  border: 2px solid fuchsia;
-  border-radius: 2px;
+/*--------------------------------------------------------------------------*\
+   DIALOG
+\*--------------------------------------------------------------------------*/
+
+[data-reach-dialog-overlay] {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  overflow: auto;
+  background: rgba(0, 0, 0, 0.7);
 }
 
-.dialog {
-  top: 50%;
-  bottom: auto;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  position: fixed;
+[role='dialog'] {
+  padding: 2.5rem;
+  border: 2px solid;
+  border-radius: 0.25rem;
+  background-color: #fff;
+}
+
+[data-reach-dialog-content] {
+  min-width: 100vw;
+  margin: 0 auto;
+  background: white;
+  outline: none;
+  z-index: 1;
+  position: relative;
+}
+
+@media screen and (min-width: 43rem) {
+  [data-reach-dialog-content] {
+    min-width: 45vw;
+    margin: 10vh auto;
+  }
+}
+
+.dialog__button {
+  background: none;
+  border: 0;
+  padding: 0;
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  line-height: 0;
+}
+
+.dialog__button svg {
+  fill: currentColor;
+  margin-top: 0.1em;
+  vertical-align: text-top;
+  width: 1rem;
+  height: 1rem;
+  cursor: pointer;
+}
+
+.dialog__image {
+  --width: 9;
+  --height: 16;
+  padding-bottom: calc(var(--width) / var(--height) * 100%);
+  position: relative;
+}
+
+.dialog__image > * {
+  overflow: hidden;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.dialog__image > img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border: 2px solid black;
+}
+
+.dialog__body__link {
+  color: #1c2334;
+}
+
+.dialog__body__link:hover {
+  text-decoration: underline;
 }

--- a/src/components/CloseIcon.js
+++ b/src/components/CloseIcon.js
@@ -1,7 +1,8 @@
 import React from 'react';
 
 const CloseIcon = () => (
-  <svg viewBox="0 0 32 32">
+  <svg viewBox="0 0 32 32" aria-labelledby="close-icon">
+    <title id="close-icon">Close Icon</title>
     <path d="M32 3.5L28.5 0 16 12.5 3.5 0 0 3.5 12.5 16 0 28.5 3.5 32 16 19.5 28.5 32l3.5-3.5L19.5 16"></path>
   </svg>
 );

--- a/src/components/CloseIcon.js
+++ b/src/components/CloseIcon.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const CloseIcon = () => (
+  <svg viewBox="0 0 32 32">
+    <path d="M32 3.5L28.5 0 16 12.5 3.5 0 0 3.5 12.5 16 0 28.5 3.5 32 16 19.5 28.5 32l3.5-3.5L19.5 16"></path>
+  </svg>
+);
+
+export default CloseIcon;

--- a/src/components/DialogBody.js
+++ b/src/components/DialogBody.js
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import CloseIcon from './CloseIcon';
+
+const DialogBody = ({ locationDetails, onClick }) => (
+  <>
+    <button className="dialog__button" onClick={onClick}>
+      <CloseIcon />
+    </button>
+
+    <div className="dialog__image">
+      <img
+        src={
+          locationDetails?.thumbnail?.source ||
+          `${process.env.PUBLIC_URL}/placeholder.png`
+        }
+        alt={locationDetails?.thumbnail?.source ? locationDetails.title : ''}
+      />
+    </div>
+    <div className="dialog__body">
+      <a
+        className="dialog__body__link"
+        href={`https://en.wikipedia.org/?curid=${locationDetails.pageid}`}
+      >
+        <h2>{locationDetails.title}</h2>
+      </a>
+      <p>{locationDetails.description}</p>
+      <p>Distance: {locationDetails.coordinates[0].dist} km</p>
+      <p></p>
+    </div>
+  </>
+);
+
+export default DialogBody;

--- a/src/components/DialogBody.js
+++ b/src/components/DialogBody.js
@@ -22,15 +22,16 @@ const DialogBody = ({ locationDetails, onClick }) => (
       />
     </div>
     <div className="dialog__body">
+      <h2>{locationDetails.title}</h2>
+      <p>{locationDetails.description}</p>
+      <p>Distance: {locationDetails.coordinates[0].dist} km</p>
       <a
         className="dialog__body__link"
         href={`https://en.wikipedia.org/?curid=${locationDetails.pageid}`}
         aria-label={`Read more about ${locationDetails.title}`}
       >
-        <h2>{locationDetails.title}</h2>
+        Learn More
       </a>
-      <p>{locationDetails.description}</p>
-      <p>Distance: {locationDetails.coordinates[0].dist} km</p>
     </div>
   </>
 );

--- a/src/components/DialogBody.js
+++ b/src/components/DialogBody.js
@@ -25,6 +25,7 @@ const DialogBody = ({ locationDetails, onClick }) => (
       <a
         className="dialog__body__link"
         href={`https://en.wikipedia.org/?curid=${locationDetails.pageid}`}
+        aria-label={`Read more about ${locationDetails.title}`}
       >
         <h2>{locationDetails.title}</h2>
       </a>

--- a/src/components/DialogBody.js
+++ b/src/components/DialogBody.js
@@ -30,7 +30,6 @@ const DialogBody = ({ locationDetails, onClick }) => (
       </a>
       <p>{locationDetails.description}</p>
       <p>Distance: {locationDetails.coordinates[0].dist} km</p>
-      <p></p>
     </div>
   </>
 );

--- a/src/components/DialogBody.js
+++ b/src/components/DialogBody.js
@@ -4,7 +4,11 @@ import CloseIcon from './CloseIcon';
 
 const DialogBody = ({ locationDetails, onClick }) => (
   <>
-    <button className="dialog__button" onClick={onClick}>
+    <button
+      className="dialog__button"
+      aria-label="close dialog"
+      onClick={onClick}
+    >
       <CloseIcon />
     </button>
 

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -62,7 +62,12 @@ const Map = () => {
                 })
               : null}
             {locationDetails && (
-              <Dialog className="dialog" aria-label="Location details"></Dialog>
+              <Dialog className="dialog" aria-label="Location details">
+                <DialogBody
+                  locationDetails={locationDetails}
+                  onClick={handleClose}
+                />
+              </Dialog>
             )}
           </GoogleMapReact>
         </div>

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -64,7 +64,11 @@ const Map = () => {
           </GoogleMapReact>
 
           {locationDetails ? (
-            <Dialog className="dialog" aria-label="Location details">
+            <Dialog
+              className="dialog"
+              aria-label="Location details"
+              onDismiss={handleClose}
+            >
               <DialogBody
                 onClick={handleClose}
                 locationDetails={locationDetails}

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -6,6 +6,7 @@ import { Dialog } from '@reach/dialog';
 import { SearchResultsContext } from '../context/SearchResults';
 
 import Pin from './Pin';
+import DialogBody from './DialogBody';
 
 const Map = () => {
   const [loaded, setLoaded] = useState(false);
@@ -61,34 +62,7 @@ const Map = () => {
                 })
               : null}
             {locationDetails && (
-              <Dialog className="dialog" aria-label="locationDetails">
-                <button>HI BUTTON CLOSE WHAT</button>
-                <div>
-                  <img
-                    src={
-                      locationDetails?.thumbnail?.source ||
-                      `${process.env.PUBLIC_URL}/placeholder.png`
-                    }
-                    alt={
-                      locationDetails?.thumbnail?.source
-                        ? locationDetails.title
-                        : ''
-                    }
-                  />
-                </div>
-                <div>
-                  <h2>{locationDetails.title}</h2>
-                  <p>{locationDetails.description}</p>
-                  <p>{locationDetails.coordinates[0].dist}</p>
-                  <p>
-                    <a
-                      href={`https://en.wikipedia.org/?curid=${locationDetails.pageid}`}
-                    >
-                      HERE IS A LINK TO MORE INFO
-                    </a>
-                  </p>
-                </div>
-              </Dialog>
+              <Dialog className="dialog" aria-label="Location details"></Dialog>
             )}
           </GoogleMapReact>
         </div>

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -7,36 +7,6 @@ import { SearchResultsContext } from '../context/SearchResults';
 
 import Pin from './Pin';
 
-// Primarily the functional requirements: describe the behaviors (functions or services) of the system that support user goals, tasks or activities. What is required by the business and product owner to accept the story? What will be verified to prove that the story provides the stakeholder-requested value?
-
-// User can tap on a pin on the map to open an Info Window with the following details about the place:
-
-// Name
-
-// Description
-
-// Thumbnail (if there is one) for the place rendered at the largest size possible within the Info Window
-
-// Distance of the place from the map center, in kms
-
-// A link to view the place on Wikipedia
-
-// Links out to Wikipedia should use the pageid property that is returned by the API, using the following format: https://en.wikipedia.org/?curid=<pageid> (e.g., https://en.wikipedia.org/?curid=60401407)
-
-// Given a user viewing the map view of the app with pins rendered, when the user taps on a pin, then an Info Window should open showing more details about the place
-
-// Given a user viewing an Info Window with more details, when they tap the close “x” the Info Window should close, returning them to the view before they opened the Info Window
-
-// Steps!!!
-// 1. install ReachUI library to retrieve reach/dialog
-// 2. create a piece of state to store the location details for where user is currently at and default it to null
-// 3. when pin is clicked, we will replace null with current location details (update the state!)
-// 4. we will need to listen for an onclick event for the pin
-// 5. when pin is clicked, it will fire a handleClick
-// 6. when handleClick is called, it will update the state by setting location details associated with the pin
-// 7. location information needs to be rendered. we will check if any location information exists, and if it exists, we will render the dialog with the existing information.
-// 8. when rendered, the dialog will have a button with an onclick handler. The button will be an 'x' in the upper corner. The handler is responsible for closing the dialog.
-
 const Map = () => {
   const [loaded, setLoaded] = useState(false);
   const [locationDetails, setLocationDetails] = useState(null);

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -1,18 +1,54 @@
 import React, { useContext, useState } from 'react';
 
 import GoogleMapReact from 'google-map-react';
+import { Dialog } from '@reach/dialog';
 
 import { SearchResultsContext } from '../context/SearchResults';
 
 import Pin from './Pin';
 
+// Primarily the functional requirements: describe the behaviors (functions or services) of the system that support user goals, tasks or activities. What is required by the business and product owner to accept the story? What will be verified to prove that the story provides the stakeholder-requested value?
+
+// User can tap on a pin on the map to open an Info Window with the following details about the place:
+
+// Name
+
+// Description
+
+// Thumbnail (if there is one) for the place rendered at the largest size possible within the Info Window
+
+// Distance of the place from the map center, in kms
+
+// A link to view the place on Wikipedia
+
+// Links out to Wikipedia should use the pageid property that is returned by the API, using the following format: https://en.wikipedia.org/?curid=<pageid> (e.g., https://en.wikipedia.org/?curid=60401407)
+
+// Given a user viewing the map view of the app with pins rendered, when the user taps on a pin, then an Info Window should open showing more details about the place
+
+// Given a user viewing an Info Window with more details, when they tap the close “x” the Info Window should close, returning them to the view before they opened the Info Window
+
+// Steps!!!
+// 1. install ReachUI library to retrieve reach/dialog
+// 2. create a piece of state to store the location details for where user is currently at and default it to null
+// 3. when pin is clicked, we will replace null with current location details (update the state!)
+// 4. we will need to listen for an onclick event for the pin
+// 5. when pin is clicked, it will fire a handleClick
+// 6. when handleClick is called, it will update the state by setting location details associated with the pin
+// 7. location information needs to be rendered. we will check if any location information exists, and if it exists, we will render the dialog with the existing information.
+// 8. when rendered, the dialog will have a button with an onclick handler. The button will be an 'x' in the upper corner. The handler is responsible for closing the dialog.
+
 const Map = () => {
   const [loaded, setLoaded] = useState(false);
+  const [locationDetails, setLocationDetails] = useState(null);
   const { data } = useContext(SearchResultsContext);
   const { centerCoords, zoom } = data;
 
   const handleApiLoaded = () => {
     setLoaded(true);
+  };
+
+  const handleClick = (location) => {
+    setLocationDetails(location);
   };
 
   return (
@@ -32,6 +68,7 @@ const Map = () => {
             {data?.query?.pages?.length > 0 && loaded
               ? data.query.pages.map((location) => {
                   const { coordinates, pageid: id } = location;
+
                   return (
                     <Pin
                       key={id}
@@ -42,10 +79,43 @@ const Map = () => {
                         `${process.env.PUBLIC_URL}/placeholder.png`
                       }
                       alt={location?.thumbnail?.source ? location.title : ''}
+                      onClick={() => {
+                        handleClick(location);
+                      }}
                     />
                   );
                 })
               : null}
+            {locationDetails && (
+              <Dialog className="dialog" aria-label="locationDetails">
+                <button>HI BUTTON CLOSE WHAT</button>
+                <div>
+                  <img
+                    src={
+                      locationDetails?.thumbnail?.source ||
+                      `${process.env.PUBLIC_URL}/placeholder.png`
+                    }
+                    alt={
+                      locationDetails?.thumbnail?.source
+                        ? locationDetails.title
+                        : ''
+                    }
+                  />
+                </div>
+                <div>
+                  <h2>{locationDetails.title}</h2>
+                  <p>{locationDetails.description}</p>
+                  <p>{locationDetails.coordinates[0].dist}</p>
+                  <p>
+                    <a
+                      href={`https://en.wikipedia.org/?curid=${locationDetails.pageid}`}
+                    >
+                      HERE IS A LINK TO MORE INFO
+                    </a>
+                  </p>
+                </div>
+              </Dialog>
+            )}
           </GoogleMapReact>
         </div>
       </div>

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -21,6 +21,10 @@ const Map = () => {
     setLocationDetails(location);
   };
 
+  const handleClose = () => {
+    setLocationDetails(null);
+  };
+
   return (
     <>
       <h1>What's Near Me?</h1>

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -2,6 +2,7 @@ import React, { useContext, useState } from 'react';
 
 import GoogleMapReact from 'google-map-react';
 import { Dialog } from '@reach/dialog';
+import '@reach/dialog/styles.css';
 
 import { SearchResultsContext } from '../context/SearchResults';
 
@@ -43,7 +44,6 @@ const Map = () => {
             {data?.query?.pages?.length > 0 && loaded
               ? data.query.pages.map((location) => {
                   const { coordinates, pageid: id } = location;
-
                   return (
                     <Pin
                       key={id}
@@ -61,15 +61,16 @@ const Map = () => {
                   );
                 })
               : null}
-            {locationDetails && (
-              <Dialog className="dialog" aria-label="Location details">
-                <DialogBody
-                  locationDetails={locationDetails}
-                  onClick={handleClose}
-                />
-              </Dialog>
-            )}
           </GoogleMapReact>
+
+          {locationDetails ? (
+            <Dialog className="dialog" aria-label="Location details">
+              <DialogBody
+                onClick={handleClose}
+                locationDetails={locationDetails}
+              />
+            </Dialog>
+          ) : null}
         </div>
       </div>
     </>

--- a/src/components/Pin.js
+++ b/src/components/Pin.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const Pin = ({ imageUrl, alt }) => (
-  <div className="map-icon bounce">
+const Pin = ({ imageUrl, alt, onClick }) => (
+  <div className="map-icon bounce" onClick={onClick} aria-hidden="true">
     <img src={imageUrl} alt={alt} />
     <svg viewBox="0 0 32 32" aria-labelledby="caret-icon">
       <title id="caret-icon">Caret Icon</title>

--- a/src/components/Pin.js
+++ b/src/components/Pin.js
@@ -3,6 +3,7 @@ import React from 'react';
 const Pin = ({ imageUrl, alt, onClick }) => (
   <div
     className="map-icon bounce"
+    onClick={onClick}
     onKeyPress={onClick}
     role="button"
     tabIndex="0"

--- a/src/components/Pin.js
+++ b/src/components/Pin.js
@@ -1,7 +1,12 @@
 import React from 'react';
 
 const Pin = ({ imageUrl, alt, onClick }) => (
-  <div className="map-icon bounce" onClick={onClick} aria-hidden="true">
+  <div
+    className="map-icon bounce"
+    onKeyPress={onClick}
+    role="button"
+    tabIndex="0"
+  >
     <img src={imageUrl} alt={alt} />
     <svg viewBox="0 0 32 32" aria-labelledby="caret-icon">
       <title id="caret-icon">Caret Icon</title>


### PR DESCRIPTION
## Description

This PR adds the ability for a user to click one of the pins rendered on the Google Map display while in `/map` view. This is also currently the home view, too. This onClick action will result in an Info Window (also referred to as "dialog" or "dialog box") to pop up. 

This Info Window is displaying the same information that would be offered in the `/list` view for each pin that is in the current `/map` view. 

The following data from Wikipedia is included in the Info Window:
- Name of Location
- Description of Location
- Thumbnail image (if there is one) associated with the location, rendered at the largest size possible within the Info Window. If no image exists, the thumbnail image space is occupied by a generic image icon.
- Distance of the place from the map center, in kilometers (kms)
- A link to access further information on Wikipedia. This link currently opens in the existing tab. 

We chose to use the [Reach UI library](https://reach.tech/dialog/) to display the Info Window. This requires updating dependencies.

Reach UI includes a basic set of styles off-the-shelf. If the included styles are to be modified, [they recommend to not remove the existing styles, but to instead, override them.](https://reach.tech/styling/) This might be helpful to note for future styling. 

## Related Issue

Closes [TCL30-11](https://the-collab-lab.atlassian.net/browse/TCL30-11)

## Acceptance Criteria

User can tap on a pin on the map to open an Info Window with the following details about the place:

- Name
- Description
- Thumbnail (if there is one) for the place rendered at the largest size possible within the Info Window
- Distance of the place from the map center, in kms
- A link to view the place on Wikipedia

Links out to Wikipedia should use the pageid property that is returned by the API, using the following format: https://en.wikipedia.org/?curid=<pageid> (e.g., https://en.wikipedia.org/?curid=60401407)

### What is included? What is excluded?

Hopefully we can use a default/built-in Info Window object, but if not it is possible to build custom Info Windows, we can use a modal ← this may actually be preferable for accessibility reasons

Given [initial context], when [event occurs], then [ensure some outcomes] (This BDD is great as it maps almost 1-1 to tests!)

Given a user viewing the map view of the app with pins rendered, when the user taps on a pin, then an Info Window should open showing more details about the place

Given a user viewing an Info Window with more details, when they tap the close “x” the Info Window should close, returning them to the view before they opened the Info Window

### What platforms need to be supported and tested?

iOS and Android

QA Verification Required: [ Call out if QA needs to test this. Link to test case if one exists. Work with QA to develop test case if this is a new area of testing, verify integration guide and release notes if applicable ]

Development for this issue can happen in-browser, but final validation should take place on a real device using a preview deploy URL to ensure the map and Info Windows behave as-expected



## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|  ✓   | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

Pins would exist, but nothing would happen when clicked.

 iPhone 6/7/8 Map View - BEFORE   |   Desktop View - BEFORE
:----------------------------------:|:-------------------------------------:
![image](https://user-images.githubusercontent.com/38255956/126910115-19d41ad5-13ab-410b-bb64-88ce06349209.png) | ![image](https://user-images.githubusercontent.com/38255956/126910117-c866711d-21df-457e-9f72-8df0cfb362b8.png)

### After

Once a pin has been clicked, the Info Window (dialog) will pop up. 

 iPhone 6/7/8 Map View - AFTER   |   Desktop View - AFTER
:----------------------------------:|:-------------------------------------:
![image](https://user-images.githubusercontent.com/16920088/126914296-a88fd188-685d-4406-bb42-7e34567f9f8b.png) | ![image](https://user-images.githubusercontent.com/16920088/126914387-331fc780-fbe9-45c4-9981-575306329526.png)


<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria

1. In the folder `tcl-30-whats-near-me`, navigate to the main branch of this project, then `git pull`
2. Switch to the branch `jw-ku-add-info-window-to-pin`
3. `npm install` (this is adding the dependencies from the Reach UI library)
4. `npm start`
5. While staying on the home view, which is also the `Map` view, click any pin that is displayed.
6. An Info Window (dialog) should appear. 
- It should contain the following information about the pin clicked:
  - Name of location
  - Information about location
  - Distance location is from center of map, in kilometers
  - Link to access location's Wikipedia page
  - Image associated with location, if available
  - If no image is included, a generic location icon will fill the space

- The Info Window will include an "x" in the upper corner to allow user to close the Info Window. 
  - The Info Window (dialog) can also be tested with Voice Over and the keyboard.
  ~~- Note that at this time, the user cannot access individual pins on the Google Map using the keyboard.~~
  - User can access individual pins on the Google Map using `tab` on the keyboard.