### PR TITLE
[TCL30-44] Get rid of the subsequent reloading of the map

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -97,7 +97,6 @@ body {
 }
 
 h1 {
-  font-size: 2.5rem;
   font-weight: 700;
   line-height: 1.12;
   text-align: center;

--- a/src/App.css
+++ b/src/App.css
@@ -112,6 +112,10 @@ main > h1 + * {
   padding: 0 0.5rem;
 }
 
+.view__header {
+  position: relative;
+}
+
 .map {
   height: 100%;
 }
@@ -156,22 +160,19 @@ a.active {
 }
 
 .spinner-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  width: 2rem;
+  height: 2rem;
   text-align: center;
-  max-width: 65rem;
-  margin-left: auto;
-  margin-right: auto;
+  margin: 0;
   padding: 0;
+  position: absolute;
+  top: 0;
+  right: 0;
 }
 
 .spinner {
-  position: absolute;
-  display: inline-block;
-  width: 30px;
-  height: 30px;
-  margin: 10px;
+  width: 2rem;
+  height: 2rem;
   border: 4px solid rgba(0, 0, 0, 0.1);
   border-left-color: #b4cddd;
   border-radius: 50%;

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -33,10 +33,7 @@ export const Map = ({
     const lat = event?.center?.lat();
     const lng = event?.center?.lng();
     const newMapCenter = { lat, lng };
-
-    window.setTimeout(() => {
-      setNewCenterMap(newMapCenter);
-    }, 1000);
+    setNewCenterMap(newMapCenter);
   };
 
   return (

--- a/src/hooks/useLocations.js
+++ b/src/hooks/useLocations.js
@@ -26,8 +26,10 @@ export const useLocations = (lat, lng) => {
         setStatus('success');
       })
       .catch((err) => {
-        setStatus('error');
-        setError(err);
+        if (err.name !== 'AbortError') {
+          setStatus('error');
+          setError(err);
+        }
       })
       .finally(() => setIsFetching(false));
 

--- a/src/pages/MapPage.js
+++ b/src/pages/MapPage.js
@@ -13,10 +13,10 @@ const MapPage = () => {
 
   return (
     <>
-      <div className="view__header">
+      <header className="view__header">
         <h1>What's Near Me?</h1>
         {status === 'loading' ? <Spinner /> : null}
-      </div>
+      </header>
       <div className="view__content">
         {status === 'error' ? <ErrorMessage error={error} /> : null}
         <Map

--- a/src/pages/MapPage.js
+++ b/src/pages/MapPage.js
@@ -13,9 +13,11 @@ const MapPage = () => {
 
   return (
     <>
-      <h1>What's Near Me?</h1>
-      <div className="view__content">
+      <div className="view__header">
+        <h1>What's Near Me?</h1>
         {status === 'loading' ? <Spinner /> : null}
+      </div>
+      <div className="view__content">
         {status === 'error' ? <ErrorMessage error={error} /> : null}
         <Map
           defaultCenterMap={defaultCenterMap}

--- a/src/pages/MapPage.js
+++ b/src/pages/MapPage.js
@@ -17,14 +17,12 @@ const MapPage = () => {
       <div className="view__content">
         {status === 'loading' ? <Spinner /> : null}
         {status === 'error' ? <ErrorMessage error={error} /> : null}
-        {status === 'success' || status === 'cancelled' ? (
-          <Map
-            defaultCenterMap={defaultCenterMap}
-            centerMap={newCenterMap}
-            locations={locations}
-            zoom={16}
-          />
-        ) : null}
+        <Map
+          defaultCenterMap={defaultCenterMap}
+          centerMap={newCenterMap}
+          locations={locations}
+          zoom={16}
+        />
       </div>
     </>
   );


### PR DESCRIPTION
## Description

When you drag our map, we reload our map, call to API with another map center location, and get new pins around the new center map.

## Related Issue

Closes [TCL30-44](https://the-collab-lab.atlassian.net/browse/TCL30-44)

## Acceptance Criteria

- If you drag our map, the map shouldn't be re-loaded.
- If you drag our map, our app should call API, and display new pins around to the new map center position.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|    | :sparkles: New feature     |
| ✓    | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

-  If you drag our map, the map should be re-loaded, and display the pins around the new map center position.

### After

-  If you drag our map, the map shouldn't be re-loaded, and display the pins around the new map center position.

## Testing Steps / QA Criteria

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->
1. Clone repository: `git clone https://github.com/the-collab-lab/tcl-30-whats-near-me`.
2. Change to PR branch: `git checkout jw-ac-mm-share-location-button`
3. Install NPM dependencies: `npm install`.
4. Run dev server: `npm run start`
5. Open your browser: `http://localhost:3000/`
6. Drag the map, and you should see new pins around the new map center position, but our map should be reloaded.