### PR TITLE
[TCL30-48] Bug: Fix Map Drag

### DIFF
--- a/src/components/ShareMyLocationButton.js
+++ b/src/components/ShareMyLocationButton.js
@@ -1,4 +1,6 @@
 import { useContext } from 'react';
+
+// import useRef as well
 import { MapCenterContext } from '../context/MapCenterContext';
 
 const ShareMyLocationButton = ({ disabled = false }) => {

--- a/src/components/ShareMyLocationButton.js
+++ b/src/components/ShareMyLocationButton.js
@@ -1,16 +1,15 @@
-import { useContext } from 'react';
+import { useContext, useRef } from 'react';
 
-// import useRef as well
 import { MapCenterContext } from '../context/MapCenterContext';
 
 const ShareMyLocationButton = ({ disabled = false }) => {
   const valueCenterMap = useContext(MapCenterContext);
+  const sharingLocation = useRef(false);
   const {
     defaultCenterMap,
     setUserCenterMap,
     setNewCenterMap,
     setTrackingId,
-    userLocationShared,
     setUserLocationShared,
     trackingId,
   } = valueCenterMap;
@@ -21,9 +20,10 @@ const ShareMyLocationButton = ({ disabled = false }) => {
     const newMapCenter = { lat, lng };
     setUserCenterMap(newMapCenter);
 
-    if (!userLocationShared) {
+    if (!sharingLocation.current) {
       setNewCenterMap(newMapCenter);
-      setUserLocationShared(true);
+      sharingLocation.current = true;
+      setUserLocationShared(sharingLocation.current);
     }
   };
   const handleError = () => setUserCenterMap(defaultCenterMap);


### PR DESCRIPTION
## Description

Observed:

- When the user shares their location, if they subsequently drag the map, the app automatically re-centers on the user’s location after a short period of time, usually between 5 to 45 seconds.

Expected:

- When the user shares their location, if they subsequently drag the map, the app stays at the new center until the user changes it.

## Related Issue

Closes [TCL30-48](https://the-collab-lab.atlassian.net/browse/TCL30-48) 

Also helps close Epic [TCL30-3](https://the-collab-lab.atlassian.net/browse/TCL30-3)

## Acceptance Criteria

User enables `Share location`

Pin showing user location appears

When user walks around, the pin should move with the user's movement

When user is standing still and drags the map, the last map view dragged to should persist until one of two things happen: 
- User clicks `Fly to me` button, or
- User drags map to new view

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|     | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

User clicks `Share location` button, map moves to where user is located.

https://user-images.githubusercontent.com/38255956/128764550-3131fa51-3e3a-4d26-b501-f2c0a29e15a4.mov

(The middle of the waiting period was trimmed out because it would have been 45 seconds of seeing nothing happen)


After user has remained at the same view that they dragged the map to, the app will eventually re-center to where the user is currently located, without a prompt from the user to do so.

https://user-images.githubusercontent.com/38255956/128764677-f6683b60-7a8c-4331-9934-22c3936c3bff.mov



### After

Expected action happens in that the map remains where the user drags the map to, despite where the user is actually located. This persists until the user again moves the map, or clicks the `Fly to me` button.

## Testing Steps / QA Criteria

1. Clone repository: `git clone https://github.com/the-collab-lab/tcl-30-whats-near-me`.
2. Change to PR branch: `git checkout jw-ac-fix-drag-map`
3. Install NPM dependencies: `npm install`.
4. Run dev server: `npm run start`
5. Open your browser: `http://localhost:3000/`
6. Click on the "Share my location" button, our map should change its center where you are.
7. Drag the map, wait for 5 or 45 sec, and it shouldn't happen anything (as a re-center our map).
8. Click on the "Fly to me" button, and you should come back to your current position if you share your location. Return to step 7. Again, it shouldn't happen anything.