### PR TITLE
[TCL30-50] UX point: Don't clear input search when you navigate between pages

### DIFF
--- a/src/components/SearchForm.js
+++ b/src/components/SearchForm.js
@@ -1,13 +1,12 @@
-import { useContext, useState } from 'react';
+import { useContext } from 'react';
 import { GoogleMapsContext } from '../context/GoogleMapsContext';
 import { MapCenterContext } from '../context/MapCenterContext';
 import planetSearch from '../assets/search-location-solid.svg';
 
 export const SearchForm = () => {
-  const [query, setQuery] = useState('');
   const valueGoogleMapsAPI = useContext(GoogleMapsContext);
   const valueMapCenter = useContext(MapCenterContext);
-  const { map, maps } = valueGoogleMapsAPI;
+  const { map, maps, query, setQuery } = valueGoogleMapsAPI;
   const { setNewCenterMap } = valueMapCenter;
 
   const handleQuery = (e) => setQuery(e.target.value);

--- a/src/context/GoogleMapsContext.js
+++ b/src/context/GoogleMapsContext.js
@@ -4,12 +4,15 @@ export const GoogleMapsContext = createContext();
 const GoogleMaps = ({ children }) => {
   const [map, setMap] = useState(null);
   const [maps, setMaps] = useState(null);
+  const [query, setQuery] = useState('');
 
   const value = {
     map,
     setMap,
     maps,
     setMaps,
+    query,
+    setQuery,
   };
 
   return (


### PR DESCRIPTION
## Description

It would be a better experience for the user if the search term were retained when moving back and forth between the map and list views.

## Related Issue

[TCL30-50](https://the-collab-lab.atlassian.net/browse/TCL30-50)

## Acceptance Criteria

- Write a someplace name in `Search` form.
- Move between `Map` and `List`.
- Input text should be cleared.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| ✓    | :bug: Bug fix              |
|    | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

![image](https://user-images.githubusercontent.com/8689897/131614099-a0211cf4-b781-45fb-939d-88b28a2ee72a.png)

![image](https://user-images.githubusercontent.com/8689897/131614128-8d98c56f-629d-4d9f-a2d2-de8bdea355e8.png)


### After

![image](https://user-images.githubusercontent.com/8689897/131613979-a0c1c893-ee11-4ab0-a1dd-717a8fd6f605.png)

![image](https://user-images.githubusercontent.com/8689897/131614026-7e98f30f-df7d-4382-b82d-bb2a17ce6d17.png)


## Testing Steps / QA Criteria

1. Checkout `ac-do-not-clear-input-search` branch.
2. Write a someplace name in `Search` form.
3. Move between `Map` and `List`.
4. Input text should be cleared.