### PR TITLE
[TCL30-64] Buttons Into Footer (Subtask)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -656,6 +656,10 @@ a.active {
   fill: var(--primary-color);
 }
 
+a.active .icon {
+  fill: var(--accent-color);
+}
+
 .icon:hover {
   fill: var(--secondary-color);
 }

--- a/src/App.css
+++ b/src/App.css
@@ -149,6 +149,7 @@ footer .btn-container {
   justify-content: flex-end;
   gap: 1rem;
   text-align: center;
+  margin-bottom: 0.5rem;
 }
 
 nav {

--- a/src/App.css
+++ b/src/App.css
@@ -143,40 +143,6 @@ main > h1 + * {
   height: 100%;
 }
 
-footer .btn-container {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  gap: 1rem;
-  text-align: center;
-  margin-bottom: 0.5rem;
-}
-
-nav {
-  max-width: 50rem;
-}
-
-.nav {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-items: center;
-  gap: 0.75rem;
-  margin: 0;
-  padding: 0;
-}
-
-.nav li {
-  margin: 0.15rem 0.5rem;
-  max-width: 65ch;
-}
-
-.nav a {
-  line-height: 1.8;
-  cursor: pointer;
-  text-decoration: none;
-}
-
 .btn {
   font-family: var(--font-family-headings);
   background-color: white;
@@ -230,12 +196,6 @@ a.active {
   letter-spacing: 1px;
   height: var(--icon-height);
   width: var(--icon-height);
-}
-
-.btn-container {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1.5rem;
 }
 
 .spinner-container {
@@ -667,4 +627,53 @@ a.active .icon {
 .icons {
   display: flex;
   gap: 1rem;
+}
+
+/* Footer */
+footer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.btn-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+
+nav {
+  max-width: 50rem;
+}
+
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+}
+
+.nav a {
+  line-height: 1.8;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+@media screen and (min-width: 568px) {
+  .nav {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0;
+    padding: 0;
+  }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -59,7 +59,6 @@ picture {
   display: block;
 }
 
-button,
 input,
 select,
 textarea {
@@ -144,13 +143,11 @@ main > h1 + * {
   height: 100%;
 }
 
-footer {
+footer .btn-container {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  align-items: center;
-  gap: 1.5rem;
+  flex-direction: row;
+  justify-content: flex-end;
+  gap: 1rem;
   text-align: center;
 }
 
@@ -174,23 +171,21 @@ nav {
 }
 
 .nav a {
-  color: #1c2334;
-  font-size: 1rem;
-  font-weight: 700;
-  line-height: 1.5;
+  line-height: 1.8;
   cursor: pointer;
   text-decoration: none;
 }
 
 .btn {
-  font-family: var(--font-family-body-text);
+  font-family: var(--font-family-headings);
   background-color: white;
   color: var(--primary-color);
-  font-size: 1.3rem;
+  font-size: 1.6rem;
+  font-weight: 700;
   gap: 1.5rem;
   line-height: 2;
   transition: all 200ms linear;
-  border-radius: 4px;
+  border-radius: 8px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -234,12 +229,6 @@ a.active {
   letter-spacing: 1px;
   height: var(--icon-height);
   width: var(--icon-height);
-}
-
-.btn-container {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1.5rem;
 }
 
 .btn-container {

--- a/src/components/FlyToMeButton.js
+++ b/src/components/FlyToMeButton.js
@@ -1,5 +1,7 @@
 import { useContext } from 'react';
 import { MapCenterContext } from '../context/MapCenterContext';
+import { Button } from '../components/Button';
+import { ReactComponent as FlyToMeIcon } from '../assets/fly-to-me-icon.svg';
 
 const FlyToMeButton = ({ disabled = false }) => {
   const valueCenterMap = useContext(MapCenterContext);
@@ -19,9 +21,13 @@ const FlyToMeButton = ({ disabled = false }) => {
   };
 
   return (
-    <button onClick={handleFlyToMe} disabled={disabled}>
-      Fly to me
-    </button>
+    <Button
+      className="btn btn__icon"
+      label="Fly to me"
+      icon={FlyToMeIcon}
+      onClick={handleFlyToMe}
+      disabled={disabled}
+    />
   );
 };
 

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,7 +1,5 @@
 import React, { useContext } from 'react';
-
 import { MapCenterContext } from '../context/MapCenterContext';
-
 import Nav from './Nav';
 import ShareMyLocationButton from './ShareMyLocationButton';
 import FlyToMeButton from './FlyToMeButton';

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -9,11 +9,11 @@ const Footer = () => {
 
   return (
     <footer>
-      <Nav />
       <div className="btn-container">
         <ShareMyLocationButton />
         <FlyToMeButton disabled={!userLocationShared} />
       </div>
+      <Nav />
     </footer>
   );
 };

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -1,21 +1,27 @@
-import { NavLink } from 'react-router-dom';
+import { ReactComponent as ListIcon } from '../assets/list-icon.svg';
+import { ReactComponent as MapIcon } from '../assets/map-icon.svg';
+import { Button } from '../components/Button';
 
 const Nav = () => (
   <nav>
     <ul className="nav">
       <li>
-        <NavLink exact to="/">
-          Map
-        </NavLink>
+        <Button
+          href="/"
+          text="Map"
+          className="btn btn__link"
+          icon={MapIcon}
+          label="Map button"
+        />
       </li>
       <li>
-        <NavLink to="/list">List</NavLink>
-      </li>
-      <li>
-        <NavLink to="/settings">Settings</NavLink>
-      </li>
-      <li>
-        <NavLink to="/help">Help</NavLink>
+        <Button
+          href="/list"
+          text="List"
+          className="btn btn__link"
+          icon={ListIcon}
+          label="List button"
+        />
       </li>
     </ul>
   </nav>

--- a/src/components/ShareMyLocationButton.js
+++ b/src/components/ShareMyLocationButton.js
@@ -1,5 +1,7 @@
 import { useContext, useRef } from 'react';
 import { MapCenterContext } from '../context/MapCenterContext';
+import { Button } from '../components/Button';
+import { ReactComponent as ShareLocationIcon } from '../assets/share-location-icon.svg';
 
 const ShareMyLocationButton = () => {
   const valueCenterMap = useContext(MapCenterContext);
@@ -54,11 +56,12 @@ const ShareMyLocationButton = () => {
   };
 
   return (
-    <button
+    <Button
+      className="btn btn__icon"
+      label="Share location"
+      icon={ShareLocationIcon}
       onClick={userLocationShared ? handleStopSharing : handleShareLiveLocation}
-    >
-      {buttonText}
-    </button>
+    />
   );
 };
 

--- a/src/components/ShareMyLocationButton.js
+++ b/src/components/ShareMyLocationButton.js
@@ -31,10 +31,6 @@ const ShareMyLocationButton = () => {
   };
   const handleError = () => setUserCenterMap(defaultCenterMap);
 
-  const buttonText = userLocationShared
-    ? 'Stop Sharing Location'
-    : 'Share My Location';
-
   const handleShareLiveLocation = () => {
     if (navigator.geolocation) {
       const trackingId = navigator.geolocation.watchPosition(

--- a/src/pages/UIComponentsPage.js
+++ b/src/pages/UIComponentsPage.js
@@ -96,6 +96,33 @@ export const UIComponentsPage = () => {
             icon={HelpIcon}
             label="Help button"
           />
+          <br />
+          <Button
+            href="/"
+            text="Map"
+            className="btn btn__link active"
+            icon={MapIcon}
+            label="Map button"
+          />
+          <Button
+            href="/list"
+            text="List"
+            className="btn btn__link active"
+            icon={ListIcon}
+            label="List button"
+          />
+          <Button
+            href="/settings"
+            className="btn btn__link--icon active"
+            icon={SettingsIcon}
+            label="Settings button"
+          />
+          <Button
+            href="/help"
+            className="btn btn__link--icon active"
+            icon={HelpIcon}
+            label="Help button"
+          />
         </div>
       </section>
       <br />


### PR DESCRIPTION

## Description

As a subtask of [TCL30-56](https://the-collab-lab.atlassian.net/browse/TCL30-56), this PR incorporates the final design of the functioning buttons into the footer. It also provides basic alignment of the buttons.

The following buttons are updated:
- Map
- List
- Fly to me
- Share my location

## Related Issue

closes TCL30-64, which is a subtask of TCL30-56

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|    | :sparkles: New feature     |
|  ✓   | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates


 iPhone 6/7/8 - BEFORE   |   iPhone 6/7/8 - AFTER
:----------------------------------:|:-------------------------------------:
<img width="358" alt="TCL30-64before" src="https://user-images.githubusercontent.com/38255956/131937089-3e96ce74-6744-44f6-9090-88ac40931c53.png"> | <img width="375" alt="Screen Shot 2021-09-02 at 9 17 56 PM" src="https://user-images.githubusercontent.com/38255956/131940627-e983a5ca-5854-496c-9624-92e8e845543d.png">


## Testing Steps / QA Criteria

1. `jw-footer-buttons`
2. `npm start`
3. Check that what you see is the same as the "After" image in this PR. 
4. Test the following buttons, that they function as expected:
- Map (`localhost:3000/`)
- List (`localhost:3000/list`)
- Share my location (should switch to screen with purple dot on map where you are currently located)
- Fly to me (when sharing your location, drag the screen so your current location icon cannot be seen on the map. Click 'Fly to me', represented with the right pointing arrow, and you should be brought back to your current location icon)