### PR TITLE
[TCL30-59] Dialog (Info Window) Styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -356,6 +356,11 @@ a.active {
   flex-direction: column;
 }
 
+.dialog__distance {
+  display: flex;
+  gap: 0.5rem;
+}
+
 .dialog__header {
   display: flex;
   justify-content: flex-end;

--- a/src/App.css
+++ b/src/App.css
@@ -18,6 +18,9 @@
   --height-location-card: 8rem;
   --height-image-location-small: 4rem;
   --height-image-location-medium: 6rem;
+  --height-dialog-info-location-small: 26rem;
+  --height-dialog-info-location-medium: 27rem;
+  --width-dialog-info-location-medium: 30rem;
   --width-location-title-small: 10rem;
   --width-location-title-medium: 20rem;
   --width-location-title-large: 23rem;
@@ -172,6 +175,10 @@ main > h1 + * {
   margin: 0;
 }
 
+.btn:focus {
+  border: 1px solid var(--primary-color);
+}
+
 .btn:hover,
 a.active {
   background-color: var(--primary-color);
@@ -318,88 +325,69 @@ a.active {
 /*--------------------------------------------------------------------------*\
    DIALOG
 \*--------------------------------------------------------------------------*/
-
 [data-reach-dialog-overlay] {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  overflow: auto;
   background: rgba(0, 0, 0, 0.7);
 }
 
-[role='dialog'] {
-  padding: 2.5rem;
-  border: 2px solid;
-  border-radius: 0.25rem;
-  background-color: #fff;
-}
-
 [data-reach-dialog-content] {
-  min-width: 100vw;
-  margin: 0 auto;
-  background: white;
-  outline: none;
-  z-index: 1;
-  position: relative;
+  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1.3rem;
+  min-height: var(--height-dialog-info-location-small);
+  width: 90%;
 }
 
-@media screen and (min-width: 43rem) {
+@media screen and (min-width: 768px) {
   [data-reach-dialog-content] {
-    min-width: 45vw;
-    margin: 10vh auto;
+    border-radius: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1.3rem;
+    height: var(--height-dialog-info-location-medium);
+    width: var(--width-dialog-info-location-medium);
   }
 }
 
-.dialog__button {
-  background: none;
-  border: 0;
-  padding: 0;
-  position: absolute;
-  top: 0.75rem;
-  right: 0.75rem;
-  line-height: 0;
+.dialog__details {
+  display: flex;
+  flex-direction: column;
 }
 
-.dialog__button svg {
-  fill: currentColor;
-  margin-top: 0.1em;
-  vertical-align: text-top;
-  width: 1rem;
-  height: 1rem;
-  cursor: pointer;
+.dialog__header {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .dialog__image {
-  --width: 9;
-  --height: 16;
-  padding-bottom: calc(var(--width) / var(--height) * 100%);
-  position: relative;
+  border-radius: 0.3rem;
 }
 
-.dialog__image > * {
-  overflow: hidden;
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+.dialog__name {
+  color: var(--primary-color);
+  font-family: var(--font-family-headings);
+  font-weight: 700;
 }
 
-.dialog__image > img {
+.dialog__distance {
+  font-family: var(--font-family-body-text);
+}
+
+.dialog__link {
   width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border: 2px solid black;
 }
 
-.dialog__body__link {
-  color: #1c2334;
-  text-decoration: underline;
+.dialog__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dialog__image {
+  height: 12rem;
+  object-fit: cover;
 }
 
 /*--------------------------------------------------------------------------*\

--- a/src/components/DialogBody.js
+++ b/src/components/DialogBody.js
@@ -1,39 +1,32 @@
-import React from 'react';
+import { Button } from './Button';
+import { ReactComponent as InfoIcon } from '../assets/info-icon.svg';
 
-import CloseIcon from './CloseIcon';
-
-const DialogBody = ({ locationDetails, onClick }) => (
-  <>
-    <button
-      className="dialog__button"
-      aria-label="close dialog"
-      onClick={onClick}
-    >
-      <CloseIcon />
-    </button>
-
-    <div className="dialog__image">
-      <img
-        src={
-          locationDetails?.thumbnail?.source ||
-          `${process.env.PUBLIC_URL}/placeholder.png`
-        }
-        alt={locationDetails?.thumbnail?.source ? locationDetails.title : ''}
-      />
+const DialogBody = ({ locationDetails }) => (
+  <div className="dialog__body">
+    <img
+      className="dialog__image"
+      src={
+        locationDetails?.thumbnail?.source ||
+        `${process.env.PUBLIC_URL}/placeholder.png`
+      }
+      alt={locationDetails?.thumbnail?.source ? locationDetails.title : ''}
+    />
+    <div className="dialog__details">
+      <h2 className="dialog__name">{locationDetails.title}</h2>
+      <p className="dialog__description">{locationDetails.description}</p>
+      <p className="dialog__distance">
+        Distance: {locationDetails.coordinates[0].dist} km
+      </p>
     </div>
-    <div className="dialog__body">
-      <h2>{locationDetails.title}</h2>
-      <p>{locationDetails.description}</p>
-      <p>Distance: {locationDetails.coordinates[0].dist} km</p>
-      <a
-        className="dialog__body__link"
-        href={`https://en.wikipedia.org/?curid=${locationDetails.pageid}`}
-        aria-label={`Read more about ${locationDetails.title}`}
-      >
-        Learn More
-      </a>
-    </div>
-  </>
+    <Button
+      href={`https://en.wikipedia.org/?curid=${locationDetails.pageid}`}
+      className="btn btn__link dialog__link"
+      icon={InfoIcon}
+      label={`Read more about ${locationDetails.title}`}
+      isLinkExternal={true}
+      text="Learn more"
+    />
+  </div>
 );
 
 export default DialogBody;

--- a/src/components/DialogBody.js
+++ b/src/components/DialogBody.js
@@ -1,4 +1,5 @@
 import { Button } from './Button';
+import { ReactComponent as MapMarkerIcon } from '../assets/map-marker-icon.svg';
 import { ReactComponent as InfoIcon } from '../assets/info-icon.svg';
 
 const DialogBody = ({ locationDetails }) => (
@@ -15,7 +16,10 @@ const DialogBody = ({ locationDetails }) => (
       <h2 className="dialog__name">{locationDetails.title}</h2>
       <p className="dialog__description">{locationDetails.description}</p>
       <p className="dialog__distance">
-        Distance: {locationDetails.coordinates[0].dist} km
+        <MapMarkerIcon />
+        <p className="location__value">
+          {locationDetails.coordinates[0].dist} Km.
+        </p>
       </p>
     </div>
     <Button

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -5,6 +5,8 @@ import '@reach/dialog/styles.css';
 import Pin from './Pin';
 import UserLocationPin from './UserLocationPin';
 import DialogBody from './DialogBody';
+import { ReactComponent as CloseIcon } from '../assets/close-icon.svg';
+import { Button } from './Button';
 import { MapCenterContext } from '../context/MapCenterContext';
 import { GoogleMapsContext } from '../context/GoogleMapsContext';
 
@@ -88,7 +90,15 @@ export const Map = ({
           aria-label="Location details"
           onDismiss={handleClose}
         >
-          <DialogBody onClick={handleClose} locationDetails={locationDetails} />
+          <div className="dialog__header">
+            <Button
+              className="btn btn__icon dialog__button dialog__button--close"
+              label="Close"
+              icon={CloseIcon}
+              onClick={handleClose}
+            />
+          </div>
+          <DialogBody locationDetails={locationDetails} />
         </Dialog>
       ) : null}
     </div>


### PR DESCRIPTION
## Description

As a user

When I click on a pin, 
I would like the dialog (info window) to match the rest of the application
and to give me an image of the location, name of the location, and distance from where I am,
So that I am not confused that I might be on a different website, 
and to know more about the location.

## Related Issue

[TCL30-59](https://the-collab-lab.atlassian.net/browse/TCL30-59)

## Acceptance Criteria

Acceptance Criteria:

At this time, no sample design has been created. Please use the examples on the Figma Whiteboard to work from

Refer to Reach UI documentation to make any visual updates. Also, refer to the following PR TCL30-11: Allow users to tap map pins for more information for further information about how the Info Window was implemented using the Reach UI library. It is also recommended to reference Stylingto assist in how to use CSS when using Reach UI in this scenario.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|    | :sparkles: New feature     |
| ✓    | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

![image](https://user-images.githubusercontent.com/8689897/132067597-d5b48d78-936e-46af-8b51-879b6224f1a4.png)

### After

![image](https://user-images.githubusercontent.com/8689897/132067631-a85dc9c6-b11a-46d3-8c9d-903b0c309215.png)

## Testing Steps / QA Criteria

1. Checkout `ac-info-window-location-styling`
2. Click some location `pin` on our map.
3. You should see a dialog (or modal).
